### PR TITLE
Additional Fixes for EhCache Commandline Args

### DIFF
--- a/persistence/persistence-api/src/main/resources/ehcache.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache.xml
@@ -8,18 +8,7 @@
     http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
     http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
 
-    <ehcache:service>
-      <jcache:defaults enable-management="true" enable-statistics="${ehcache.statistics_enabled}"/>
-    </ehcache:service>
-
-    <ehcache:persistence directory="${ehcache.persistence_path}"/><!-- remove if using a heap-only cache -->
-
-    <ehcache:heap-store>
-      <ehcache:max-object-graph-size>9223372036854775807</ehcache:max-object-graph-size><!-- using Long.MAX_VALUE -->
-      <ehcache:max-object-size>9223372036854775807</ehcache:max-object-size><!-- using Long.MAX_VALUE -->
-    </ehcache:heap-store>
-
-    <ehcache:cache-template name="GeneralRepositoryCache">
+    <ehcache:cache-template name="RepositoryCacheTemplate">
       <ehcache:expiry>
         <ehcache:none></ehcache:none>
       </ehcache:expiry>
@@ -35,32 +24,6 @@
           <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
         </ehcache:listener>
       </ehcache:listeners>
-      <ehcache:resources>
-        <ehcache:heap unit="MB">${ehcache.general_repository_cache.max_mega_bytes_heap}</ehcache:heap><!-- remove if using a disk-only cache -->
-        <ehcache:disk unit="MB" persistent="false">${ehcache.general_repository_cache.max_mega_bytes_local_disk}</ehcache:disk><!-- remove if using a heap-only cache -->
-      </ehcache:resources>
-    </ehcache:cache-template>
-
-    <ehcache:cache-template name="StaticRepositoryCacheOne">
-      <ehcache:expiry>
-        <ehcache:none></ehcache:none>
-      </ehcache:expiry>
-      <ehcache:listeners>
-        <ehcache:listener>
-          <ehcache:class>org.cbioportal.persistence.util.CacheEventLogger</ehcache:class>
-          <ehcache:event-firing-mode>ASYNCHRONOUS</ehcache:event-firing-mode>
-          <ehcache:event-ordering-mode>UNORDERED</ehcache:event-ordering-mode>
-          <ehcache:events-to-fire-on>CREATED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>REMOVED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>EXPIRED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>EVICTED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
-        </ehcache:listener>
-      </ehcache:listeners>
-      <ehcache:resources>
-        <ehcache:heap unit="MB">${ehcache.static_repository_cache_one.max_mega_bytes_heap}</ehcache:heap><!-- remove if using a disk-only cache -->
-        <ehcache:disk unit="MB" persistent="false">${ehcache.static_repository_cache_one.max_mega_bytes_local_disk}</ehcache:disk><!-- remove if using a heap-only cache -->
-      </ehcache:resources>
     </ehcache:cache-template>
 
 </ehcache:config>


### PR DESCRIPTION
ehcache.xml switched to a more general template instead of initializing each individual cache
properties now auto-wired in through CustomEhCacheProvider

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
