### PR TITLE
Documentation & Switch ehcache.cache_enabled to ehcache.cache_type

### DIFF
--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -13,7 +13,7 @@ ResourcePoolsBuilder clinicalDataCacheResourcePoolsBuilder = ResourcePoolsBuilde
 clinicalDataCacheResourcePoolsBuilder.heap(clinicalDataCacheHeapSize, MemoryUnit.MB);
 clinicalDataCacheResourcePoolsBuilder.disk(clinicalDataCacheDiskSize, MemoryUnit.MB);
 ```
-After, create a CacheConfiguration for the new cache using the new `ResourcePoolsBuilder` just created.
+After initialzing the `ResourcePoolsBuilder`, create a CacheConfiguration for the new cache using the new `ResourcePoolsBuilder` just created.
 ```
 CacheConfiguration<Object, Object> clinicalDataCacheConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", 
 Object.class, Object.class, clinicalDataCacheResourcePoolsBuilder)

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -2,16 +2,36 @@
 cBioPortal provides the option of caching information on the backend to improve performance. Without caching, every time a request is received by the backend, a query is sent to the database system for information, and the returned data is processed to construct a response. This may lead to performance issues as the entire process can be rather costly, especially for queries on larger studies. With caching turned on, query responses can be taken directly from the cache if they have already been constructed. They would only be constructed for the initial query.
 
 ## Cache Configuration
-The portal is configured to use Ehcache for backend caching; caching configuration is specified inside an xml file under `persistence/persistence-api/src/main/resources`. The default configuration is a hybrid (disk + heap); however, Ehcache supports both a disk-only and heap-only mode. Refer to comments in `ehcache.xml` to switch between cache configurations. The configuration files also specify which caches to create. Additional specifications such as cache size and location are set inside `portal.properties` (more information [here](portal.properties-Reference.md#ehcache-settings)).
+The portal is configured to use Ehcache for backend caching. Ehcache supports a hybrid (disk + heap), disk-only, and heap-only mode; this, along with additional specifications such as cache size and location, are set inside `portal.properties`(more information [here](portal.properties-Reference.md#ehcache-settings)). 
  
 ## Creating additional caches
-The default configuration initializes two separate caches. However, you may wish to introduce new caches with different policies (e.g expiration policy) for different datatypes. To create additional caches (e.g creating a cache specifically for clinical data), a new cache must be added to the Ehcache xml configuration file. The `@Cacheable` annotation must also be added (or adjusted) to function declarations to indicate which functions are to be cached. Those might look like this example:
+Cache initialization is handled inside the [CustomEhCachingProvider](../persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java). The default configuration initializes two seperate caches; however, you may wish to introduce new caches for different datatypes. To create additional caches (e.g creating a cache specifically for clinical data), a new cache must be added to the CustomEhCachingProvider. 
+
+Within the CustomEhCachingProvider, initialize a new `ResourcePoolsBuilder` for the new cache and set the resources accordingly. 
+```
+ResourcePoolsBuilder clinicalDataCacheResourcePoolsBuilder = ResourcePoolsBuilder.newResourcePoolsBuilder();
+clinicalDataCacheResourcePoolsBuilder.heap(clinicalDataCacheHeapSize, MemoryUnit.MB);
+clinicalDataCacheResourcePoolsBuilder.disk(clinicalDataCacheDiskSize, MemoryUnit.MB);
+```
+After, create a CacheConfiguration for the new cache using the new `ResourcePoolsBuilder` just created.
+```
+CacheConfiguration<Object, Object> clinicalDataCacheConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", 
+Object.class, Object.class, clinicalDataCacheResourcePoolsBuilder)
+.withSizeOfMaxObjectGraph(Long.MAX_VALUE)
+.withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B)
+.build();
+```
+Finally, add the new `CacheConfiguration` to the map of managed caches with a name for the cache. 
+```
+caches.put("ClinicalDataCache", ClinicalDataCacheConfiguration);
+```
+The `@Cacheable` annotation must also be added (or adjusted) to function declarations to indicate which functions are to be cached. Those might look like this example:
 ``` 
 @Cacheable(cacheNames = "ClinicalDataCache", condition = "@cacheEnabledConfig.getEnabled()")
 public String getDataFromClinicalDataRepository(String param) {}
 ```
 Additionally, new properties for setting cache sizes should be added to `portal.properties`. Alternatively, values may also be hardcoded directly into the Ehcache xml configuration file. 
 
-For more information on constructing an Ehcache xml configuration file, refer to the documentation [here](https://www.ehcache.org/documentation/3.7/xml.html). 
+For more information on cache templates and the Ehcache xml configuration file, refer to the documentation [here](https://www.ehcache.org/documentation/3.7/xml.html). 
 
 For more information on linking caches to functions, refer to the documentation [here](https://spring.io/guides/gs/caching/).

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -7,11 +7,11 @@ The portal is configured to use Ehcache for backend caching. Ehcache supports a 
 ## Creating additional caches
 Cache initialization is handled inside the [CustomEhCachingProvider](../persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java). The default configuration initializes two seperate caches; however, you may wish to introduce new caches for different datatypes. To create additional caches (e.g creating a cache specifically for clinical data), a new cache must be added to the CustomEhCachingProvider. 
 
-Within the CustomEhCachingProvider, initialize a new `ResourcePoolsBuilder` for the new cache and set the resources accordingly. 
+Within the `CustomEhCachingProvider`, initialize a new `ResourcePoolsBuilder` for the new cache and set the resources accordingly. 
 ```
 ResourcePoolsBuilder clinicalDataCacheResourcePoolsBuilder = ResourcePoolsBuilder.newResourcePoolsBuilder();
-clinicalDataCacheResourcePoolsBuilder.heap(clinicalDataCacheHeapSize, MemoryUnit.MB);
-clinicalDataCacheResourcePoolsBuilder.disk(clinicalDataCacheDiskSize, MemoryUnit.MB);
+clinicalDataCacheResourcePoolsBuilder = clinicalDataCacheResourcePoolsBuilder.heap(clinicalDataCacheHeapSize, MemoryUnit.MB);
+clinicalDataCacheResourcePoolsBuilder = clinicalDataCacheResourcePoolsBuilder.disk(clinicalDataCacheDiskSize, MemoryUnit.MB);
 ```
 After initialzing the `ResourcePoolsBuilder`, create a CacheConfiguration for the new cache using the new `ResourcePoolsBuilder` just created.
 ```
@@ -30,7 +30,7 @@ The `@Cacheable` annotation must also be added (or adjusted) to function declara
 @Cacheable(cacheNames = "ClinicalDataCache", condition = "@cacheEnabledConfig.getEnabled()")
 public String getDataFromClinicalDataRepository(String param) {}
 ```
-Additionally, new properties for setting cache sizes should be added to `portal.properties`. Alternatively, values may also be hardcoded directly into the Ehcache xml configuration file. 
+Additionally, new properties for setting cache sizes should be added to `portal.properties` and loaded into the [CustomEhCachingProvider](../persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java). Alternatively, values may be hardcoded directly inside [CustomEhCachingProvider](../persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java).
 
 For more information on cache templates and the Ehcache xml configuration file, refer to the documentation [here](https://www.ehcache.org/documentation/3.7/xml.html). 
 

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -284,12 +284,12 @@ This gene set will add the following in the query box:
 # Ehcache Settings
 cBioPortal is supported on the backend with Ehcache. The configuration, size, and location of these caches are configurable from within portal.properties through the following properties.
 
-Caching is disabled by default. When caching is disabled, no respones will be stored in cache. To turn on caching set `ehcache.cache_enabled` to true.  
+The cache type is set using `ehcache.cache_type`. Valid values are `none`, `heap` (heap-only), `disk` (disk-only), and `hybrid` (disk + heap). By default, `ehcache.cache_type` is set to `none` which disables the cache. When the cache is disabled, no responses will be stored in the cache. 
 ```
-ehcache.cache_enabled=true
+ehcache.cache_type=[none or heap or disk or hybrid]
 ```
 
-When caching is enabled, set a cache configuration using `ehcache.xml_configuration`. This should be the name of an Ehcache xml configuration file; the default provided is `ehcache.xml` which configures a hybrid (disk + heap) cache. To change caching configuration, directly edit `/ehcache.xml`. Alternatively, you can create your own Ehcache xml configuration file, place it under `/persistence/persistence-api/src/main/resources/` and set `ehcache.xml_configuration` to `/[Ehcache xml configuration filename]`.  
+Ehcache initializes caches based off of a template found in an Ehcache xml configuration file. When caching is enabled, set `ehcache.xml_configuration` to the name of the Ehcache xml configuration file. The default provided is `ehcache.xml`; to change the cache template, directly edit this file. Alternatively, you can create your own Ehcache xml configuration file, place it under `/persistence/persistence-api/src/main/resources/` and set `ehcache.xml_configuration` to `/[Ehcache xml configuration filename]`.  
 ```
 ehcache.xml_configuration=
 ```

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
@@ -1,13 +1,30 @@
 package org.cbioportal.persistence;
 
 import org.springframework.beans.factory.annotation.Value;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class CacheEnabledConfig {
 
     private boolean enabled;
+    
+    public static final String DISK = "disk";
+    public static final String HEAP = "heap";
+    public static final String HYBRID = "hybrid";
 
-    public CacheEnabledConfig(String cacheEnabled) {
-        this.enabled = Boolean.parseBoolean(cacheEnabled);
+    public static ArrayList<String> validCacheTypes = new ArrayList<String>(Arrays.asList(DISK, HEAP, HYBRID));
+
+    public CacheEnabledConfig(String cacheType) {
+        this.enabled = parseCacheType(cacheType);
+    }
+
+    public static boolean parseCacheType(String cacheType) {
+        for (String validCacheType : validCacheTypes) {
+            if (cacheType.equalsIgnoreCase(validCacheType)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public String getEnabled() {

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java
@@ -107,8 +107,16 @@ public class CustomEhCachingProvider extends EhcacheCachingProvider {
                     staticRepositoryCacheOneResourcePoolsBuilder = staticRepositoryCacheOneResourcePoolsBuilder.disk(staticRepositoryCacheOneMaxMegaBytesLocalDisk, MemoryUnit.MB);
                 }
 
-                CacheConfiguration<Object, Object> generalRepositoryCacheConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", Object.class, Object.class, generalRepositoryCacheResourcePoolsBuilder).withSizeOfMaxObjectGraph(Long.MAX_VALUE).withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B).build();
-                CacheConfiguration<Object, Object> staticRepositoryCacheOneConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", Object.class, Object.class, staticRepositoryCacheOneResourcePoolsBuilder).withSizeOfMaxObjectGraph(Long.MAX_VALUE).withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B).build();
+                CacheConfiguration<Object, Object> generalRepositoryCacheConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", 
+                        Object.class, Object.class, generalRepositoryCacheResourcePoolsBuilder)
+                    .withSizeOfMaxObjectGraph(Long.MAX_VALUE)
+                    .withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B)
+                    .build();
+                CacheConfiguration<Object, Object> staticRepositoryCacheOneConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", 
+                        Object.class, Object.class, staticRepositoryCacheOneResourcePoolsBuilder)
+                    .withSizeOfMaxObjectGraph(Long.MAX_VALUE)
+                    .withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B)
+                    .build();
 
                 // places caches in a map which will be used to create cache manager
                 Map<String, CacheConfiguration<?, ?>> caches = new HashMap<>();
@@ -116,11 +124,9 @@ public class CustomEhCachingProvider extends EhcacheCachingProvider {
                 caches.put("StaticRepositoryCacheOne", staticRepositoryCacheOneConfiguration);
 
                 Configuration configuration = null;
-
-                // provide a persistence configuration for non heap-only caches
                 if (cacheType.equalsIgnoreCase(CacheEnabledConfig.HEAP)) {
                     configuration = new DefaultConfiguration(caches, this.getDefaultClassLoader());
-                } else {
+                } else { // add persistence configuration if cacheType is either disk-only or hybrid
                     File persistenceFile = new File(persistencePath);
                     configuration = new DefaultConfiguration(caches, this.getDefaultClassLoader(), new DefaultPersistenceConfiguration(persistenceFile));
                 }

--- a/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
+++ b/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
@@ -12,7 +12,7 @@
     <cache:annotation-driven cache-manager="cacheManager" key-generator="customKeyGenerator"/>
 
     <bean id="cacheEnabledConfig" class="org.cbioportal.persistence.CacheEnabledConfig">
-        <constructor-arg value="${ehcache.cache_enabled:false}"/>
+        <constructor-arg value="${ehcache.cache_type:none}"/>
     </bean>
 
     <bean id="customEhCacheProvider" class="org.cbioportal.persistence.util.CustomEhCachingProvider"/>


### PR DESCRIPTION
# What? Why?
Previous implementation made switching cache configurations (disk, heap, hybrid) confusing. 
e.g default is heap, but if persistence directory is set it uses hybrid
Also, disk-only configuration was not possible (?) without changing the code and recompiling since cache sets heap resource no matter what. Or would have to set heap to specifically 0? (commenting out doesn't work because it would default to a number)

Changes proposed in this pull request:
Change `ehcache.cache_enabled` to `ehcache.cache_type`. 
`ehcache.cache_type=[disk, heap, hybrid]` is equivalent to `ehcache.cache_enabled = true`
ResourcePools are initialized based on `ehcache.cache_type`

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
